### PR TITLE
Release v0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: rust
 
-matrix:
-  include:
-    - env: TARGET=x86_64-unknown-linux-gnu
-      rust: nightly
+env:
+  - TARGET=x86_64-unknown-linux-gnu
+  - TARGET=thumbv7m-none-eabi
+rust:
+  - nightly
+  - beta
+  - stable
 
 before_install:
   - set -e
@@ -21,6 +24,11 @@ cache: cargo
 before_cache:
   # Travis can't cache files that are not readable by "others"
   - chmod -R a+r $HOME/.cargo
+
+branches:
+  only:
+  - master
+  - testing
 
 notifications:
   email:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ keywords = ["embedded-hal-driver", "loadcell", "hx711", "amplifier", "adc"]
 repository = "https://github.com/jonas-hagen/hx711"
 license = "MIT OR Apache-2.0"
 
+[features]
+never_type = []
+
 [dependencies]
 nb = "0.1.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ never_type = []
 nb = "0.1.2"
 
 [dependencies.embedded-hal]
-version = "0.2.3"
+version = "0.2.4"
 features = ["unproven"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hx711"
-version = "0.4.0"
+version = "0.5.0"
 description = "A platform agnostic driver to interface with the HX711 (load cell amplifier and ADC)"
 authors = ["Jonas Hagen <jonas.hagen3@gmail.com>"]
 categories = ["embedded", "hardware-support", "no-std"]

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Some random notes on this topic:
 
 ## Changelog
 
-### v0.5 (next release)
+### v0.5
 
 - Hide usage of `never_type` behind feature for usage on stable rust
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ Because the interface works by toggling of GPIO pins, some care has to be taken.
 
 See here: https://github.com/jonas-hagen/hx711-examples
 
+Incomplete appetizer:
+```rust
+let mut val: i32 = 0;
+
+let dout = gpioa.pa6.into_floating_input(&mut gpioa.crl);
+let pd_sck = gpioa.pa7.into_push_pull_output(&mut gpioa.crl);
+
+let mut hx711 = Hx711::new(Delay::new(cp.SYST, clocks), dout, pd_sck).into_ok();
+
+// Obtain the tara value
+writeln!(tx, "Obtaining tara ...").unwrap();
+const N: i32 = 8;
+for _ in 0..N {
+    val += block!(hx711.retrieve()).into_ok(); // or unwrap, see features below
+}
+let tara = val / N;
+writeln!(tx, "Tara:   {}", tara).unwrap();
+```
+
 ## Optional features
 
 ### `never_type`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ Because the interface works by toggling of GPIO pins, some care has to be taken.
 
 See here: https://github.com/jonas-hagen/hx711-examples
 
+## Optional features
+
+### `never_type`
+
+The `never_type` feature can optionally be enabled when using nightly rust.
+
+For some HALs, the digital input and output pins can never fail.
+When using the driver with such a crate, one can use `.into_ok()` on all results instead of `.unwrap()` or `.expect()`.
+
+Example with e.g. STM32f1xx embedded hal:
+```rust
+// Without never_type (stable rust):
+// We know that this never fails
+let weight = block!(hx711.retrieve()).unwrap())
+
+// With never_type (nightly rust)
+// It is obvious that this is always ok
+let weight = block!(hx711.retrieve()).into_ok()
+```
+
 ## Bit-banging and delays
 
 The protocol is implemented using the GPIO interface because the HX711 needs a specific number of clock cycles to set the operation mode (25, 26 or 27 cycles). 
@@ -77,6 +97,10 @@ Some random notes on this topic:
 * How to make this work on linux? Any ideas?
 
 ## Changelog
+
+### v0.5 (next release)
+
+- Hide usage of `never_type` behind feature for usage on stable rust
 
 ### v0.4
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,7 +2,13 @@ set -euxo pipefail
 
 main() {
     cargo check --target $TARGET
-    cargo test
+    case $TARGET in
+        x86_64*)
+            cargo test
+            ;;
+        *)
+            ;;
+    esac
 }
 
 main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,10 +1,26 @@
 set -euxo pipefail
 
+run_tests() {
+    case $TRAVIS_RUST_VERSION in
+        stable)
+            cargo test
+            ;;
+        beta)
+            cargo test
+            ;;
+        nightly)
+            cargo test --features "never_type"
+            ;;
+        *)
+            ;;
+    esac
+}
+
 main() {
     cargo check --target $TARGET
     case $TARGET in
         x86_64*)
-            cargo test
+            run_tests
             ;;
         *)
             ;;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ where
     pub fn enable(&mut self) -> Result<(), Error<EIN, EOUT>> {
         self.pd_sck.set_low().map_err(Error::Output)?;
         self.delay.delay_us(TIME_SCK_LOW);
-        nb::block!{self.set_mode(self.mode)}
+        nb::block! {self.set_mode(self.mode)}
     }
 
     /// Reset the chip.


### PR DESCRIPTION
This mainly fixes #3 by hiding the usage of `never_type` behind an optional feature.
Also, include CI/CD for stable and beta rust channels.