### PR TITLE
Fix naming and comments of mode Enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hx711"
-version = "0.6.0"
+version = "0.7.0"
 description = "A platform agnostic driver to interface with the HX711 (load cell amplifier and ADC)"
 authors = ["Jonas Hagen <jonas.hagen3@gmail.com>"]
 categories = ["embedded", "hardware-support", "no-std"]

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Some random notes on this topic:
 
 ## Changelog
 
+### v0.7
+
+- Fix naming of mode Enum. This is a breaking change if the mode `ChBGain64` is used (which does not exist in hardware). Thanks *joelsa*!
+
 ### v0.6
 
 - Update nb requirement to 1.0.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,15 +162,15 @@ where
     }
 }
 
-/// The HX711 can run in three modes:
+/// The HX711 can run in three modes (see Table 3 in Datasheet):
 #[derive(Copy, Clone)]
 pub enum Mode {
     /// Chanel A with factor 128 gain
     ChAGain128 = 1,
-    /// Chanel B with factor 64 gain
-    ChBGain32 = 2,
     /// Chanel B with factor 32 gain
-    ChBGain64 = 3,
+    ChBGain32 = 2,
+    /// Chanel A with factor 64 gain
+    ChAGain64 = 3,
 }
 
 /// Convert 24 bit signed integer to i32


### PR DESCRIPTION
Fixes #8.

This is a breaking change, but we can argue that nobody would be affected.